### PR TITLE
Updated linear-converter to version 6.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "floating-adapter": "1.2.0",
     "for-own": "0.1.3",
     "arbitrary-precision": "1.1.1",
-    "linear-converter": "6.0.3",
+    "linear-converter": "6.0.4",
     "linear-presets": "1.1.11",
     "lodash.flow": "3.2.1"
   }


### PR DESCRIPTION
:rocket:

linear-converter just published version 6.0.4, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 4 commits (ahead by 4, behind by 0).
- [6009910](https://github.com/javiercejudo/linear-converter/commit/6009910159ff1e5fe2242a40ec0d29f2b16dc896): 6.0.4
- [82b8aeb](https://github.com/javiercejudo/linear-converter/commit/82b8aeb030ad64bd3808f68d408b8dd3c6b752bb): docs(README): update examples to not use linear-presets
- [6804f2f](https://github.com/javiercejudo/linear-converter/commit/6804f2ff921fb51be81d49b7d97c912c7aa2fb96): test: fix browser test
- [e3b2cac](https://github.com/javiercejudo/linear-converter/commit/e3b2cac005743082ba67bfbea6f51c22f949d1e8): test(browsers): run test on Microsoft Edge

See the [full diff](https://github.com/javiercejudo/linear-converter/compare/5769d260604a60e052f830c3e33d91f5df023cce...6009910159ff1e5fe2242a40ec0d29f2b16dc896).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
