### PR TITLE
Updated linear-converter to version 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "arbitrary-precision": "1.1.1",
     "floating-adapter": "1.2.0",
     "for-own": "0.1.3",
-    "linear-converter": "6.0.4",
+    "linear-converter": "7.0.0",
     "linear-preset-factory": "^1.0.2",
     "linear-presets": "2.0.0",
     "lodash.flow": "3.2.1"

--- a/src/linear-converter-to-go.js
+++ b/src/linear-converter-to-go.js
@@ -23,7 +23,7 @@ var lcApi = lcFactory(Decimal);
 var api = {};
 
 var asIs = {
-  equivalentPresets: lcApi.equivalentPresets
+  equivalentConversions: lcApi.equivalentConversions
 };
 
 var numerical = {
@@ -33,8 +33,8 @@ var numerical = {
 };
 
 var presetNumerical = {
-  invertPreset: lcApi.invertPreset,
-  composePresets: lcApi.composePresets
+  invertConversion: lcApi.invertConversion,
+  composeConversions: lcApi.composeConversions
 };
 
 forOwn(asIs, function(fn, name) {

--- a/test/spec.js
+++ b/test/spec.js
@@ -35,11 +35,28 @@ describe('linear converter to go', function() {
   });
 
   it('should invert presets', function() {
-    lc.invertPreset([[0, 1], [0, 3]]).should.eql([[0, 3], [0, 1]]);
+    lc.invertConversion([[0, 1], [0, 3]]).should.eql([[0, 3], [0, 1]]);
   });
 
   it('should compose presets returning scales with primitive numbers', function() {
-    lc.composePresets([[0, 1], [0, 3]], [[0, 1], [1, 2]]).should.eql([[0, 1], [1, 4]]);
+    lc.composeConversions([[0, 1], [0, 3]], [[0, 1], [1, 2]]).should.eql([[0, 1], [1, 4]]);
+  });
+
+  it('should be able to test for equavalence', function() {
+    lc.equivalentConversions(
+      [[0, 10], [10, 20]],
+      [[430245.1, -44.5], [430255.1, -34.5]]
+    ).should.be.exactly(true);
+
+    lc.equivalentConversions(
+      [[0, 1], [0, 2]],
+      [[0, 1], [0, 3]]
+    ).should.be.exactly(false);
+
+    lc.equivalentConversions(
+      [[0, 1], [1, 3]],
+      [[0, 1], [2, 4]]
+    ).should.be.exactly(false);
   });
 
   it('should calculate coefficients as primitive numbers', function() {


### PR DESCRIPTION
:rocket:

linear-converter just published version 7.0.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 3 commits (ahead by 3, behind by 0).
- [4f8b27a](https://github.com/javiercejudo/linear-converter/commit/4f8b27aa7fade79a16ad58ac88c6c07a01ea43fc): 7.0.0
- [c2f9705](https://github.com/javiercejudo/linear-converter/commit/c2f97059c6783b4f454d2771e885fce76372b0f6): Merge pull request #22 from javiercejudo/api-changes
- [b9e7745](https://github.com/javiercejudo/linear-converter/commit/b9e77450b64a32d599a69d01beb8e9407746f51e): feat(api): rename api methods to replace preset with conversion

See the [full diff](https://github.com/javiercejudo/linear-converter/compare/6009910159ff1e5fe2242a40ec0d29f2b16dc896...4f8b27aa7fade79a16ad58ac88c6c07a01ea43fc).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
