### PR TITLE
Updated linear-presets to version 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "floating-adapter": "1.2.0",
     "linear-converter": "7.0.1",
     "linear-preset-factory": "1.0.2",
-    "linear-presets": "2.0.0",
+    "linear-presets": "2.0.2",
     "lodash.flow": "3.2.1",
     "lodash.identity": "3.0.0"
   }


### PR DESCRIPTION
:rocket:

linear-presets just published version 2.0.2, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 6 commits (ahead by 6, behind by 0).
- [9665757](https://github.com/javiercejudo/linear-presets/commit/9665757e7efa9d9443d351190ce43c0c1a59b7a2): 2.0.2
- [88f8110](https://github.com/javiercejudo/linear-presets/commit/88f8110e60d07b9e4d1810e7185ad2a11a059917): fix(deps): update deps to latest
- [522ed54](https://github.com/javiercejudo/linear-presets/commit/522ed54d90104fbcd1b1d9119184a45ca8392a26): 2.0.1
- [322cb4f](https://github.com/javiercejudo/linear-presets/commit/322cb4fd788701725e09fb96283c00ca70426b4b): refactor(velocity): separated as external module
- [5fcd102](https://github.com/javiercejudo/linear-presets/commit/5fcd102d5d659129726147e20968d220cdfa8cef): Merge pull request #6 from javiercejudo/greenkeeper-should-7.1.0
- [25fc04b](https://github.com/javiercejudo/linear-presets/commit/25fc04b5a39256d45b3bdda8eb680e23cca5351d): chore(package): update should to version 7.1.0

See the [full diff](https://github.com/javiercejudo/linear-presets/compare/6399d78c648d12bbdc89820c2a1a6337827ead74...9665757e7efa9d9443d351190ce43c0c1a59b7a2).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
