### PR TITLE
Updated linear-presets to version 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "floating-adapter": "1.2.0",
     "linear-converter": "7.0.1",
     "linear-preset-factory": "1.0.2",
-    "linear-presets": "2.0.2",
+    "linear-presets": "2.0.3",
     "lodash.flow": "3.2.1",
     "lodash.identity": "3.0.0"
   }


### PR DESCRIPTION
:rocket:

linear-presets just published version 2.0.3, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 2 commits (ahead by 2, behind by 0).
- [b3ddcbd](https://github.com/javiercejudo/linear-presets/commit/b3ddcbd3614b9ce1632d5c469d9109147f67f6f6): 2.0.3
- [4af2bf8](https://github.com/javiercejudo/linear-presets/commit/4af2bf8c19b0bd31c0fe9387bc4f9b50b7fb9137): refactor(angle): separated as external module

See the [full diff](https://github.com/javiercejudo/linear-presets/compare/9665757e7efa9d9443d351190ce43c0c1a59b7a2...b3ddcbd3614b9ce1632d5c469d9109147f67f6f6).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
